### PR TITLE
feat: export and import document content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
 dist/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@ A collaborative text editor written in Go.
 
 ![Preview](.github/assets/demo.gif)
 
+## Features
+
+- Lightweight (~4MB)
+- Easy to setup (single binary, Docker/Fly setup available!)
+- Export/import document content! (see [keybindings](#keybindings))
+
+## Keybindings
+
+| Action         | Key |
+|--------------|:-----:|
+| Exit |  `Esc` |
+| Save to document (needs `-file` flag to supplied during startup) |  `Ctrl+S` |
+| Load from document (needs `-file` flag to supplied during startup) |  `Ctrl+L` |
+| Move cursor up/left |  `Left arrow key` |
+| Move cursor down/right |  `Right arrow key` |
+| Move cursor to start |  `Home` |
+| Move cursor to end|  `End` |
+
 ## Usage
 
 The easiest way to get started is to download `rowix` from the [releases](https://github.com/burntcarrot/rowix/releases).

--- a/client/main.go
+++ b/client/main.go
@@ -255,7 +255,13 @@ func handleTermboxEvent(ev termbox.Event, conn *websocket.Conn) error {
 			return errors.New("rowix: exiting")
 		case termbox.KeyCtrlS:
 			if fileName != "" {
-				crdt.Save(fileName, &doc)
+				err := crdt.Save(fileName, &doc)
+				if err != nil {
+					e.StatusMsg = "Failed to save to " + fileName
+					logrus.Errorf("failed to save to file %s", fileName)
+					e.SetStatusBar()
+					return err
+				}
 				e.StatusMsg = "Saved document to " + fileName
 				e.SetStatusBar()
 			} else {
@@ -271,6 +277,8 @@ func handleTermboxEvent(ev termbox.Event, conn *websocket.Conn) error {
 				if err != nil {
 					e.StatusMsg = "Failed to load " + fileName
 					logrus.Errorf("failed to load file %s", fileName)
+					e.SetStatusBar()
+					return err
 				}
 				doc = newDoc
 				e.SetX(0)

--- a/client/main.go
+++ b/client/main.go
@@ -51,7 +51,7 @@ var conn *websocket.Conn
 // termbox-based editor.
 var e *editor.Editor
 
-// name of file to load from and save to
+// The name of the file to load from and save to.
 var fileName string
 
 func main() {
@@ -465,7 +465,6 @@ func rowixDirExists(rowixDir string) bool {
 			if err = os.Chmod(rowixDir, 0744); err != nil {
 				return false
 			} else {
-
 				return true
 			}
 		}

--- a/client/main.go
+++ b/client/main.go
@@ -270,7 +270,7 @@ func handleTermboxEvent(ev termbox.Event, conn *websocket.Conn) error {
 				e.SetStatusBar()
 				if err != nil {
 					e.StatusMsg = "Failed to load " + fileName
-					logrus.Error("failed to load file %s", fileName)
+					logrus.Errorf("failed to load file %s", fileName)
 				}
 				doc = newDoc
 				e.SetX(0)

--- a/crdt/woot.go
+++ b/crdt/woot.go
@@ -3,6 +3,9 @@ package crdt
 import (
 	"errors"
 	"fmt"
+	"io/fs"
+	"os"
+	"strings"
 )
 
 // Document is composed of characters.
@@ -41,6 +44,33 @@ var (
 // New returns a initialized document.
 func New() Document {
 	return Document{Characters: []Character{CharacterStart, CharacterEnd}}
+}
+
+// Load reads a text file from disk and converts it into a CRDT document.
+func Load(fileName string) (Document, error) {
+	doc := New()
+	b, err := os.ReadFile(fileName)
+	if err != nil {
+		return doc, err
+	}
+	lines := strings.Split(string(b), "\n")
+	pos := 1
+	for i := 0; i < len(lines); i++ {
+		for j := 0; j < len(lines[i]); j++ {
+			doc.Insert(pos, string(lines[i][j]))
+			pos++
+		}
+		if i < len(lines)-1 {
+			doc.Insert(pos, "\n")
+			pos++
+		}
+	}
+	return doc, err
+}
+
+// Save writes data to the named file, creating it if necessary. The contents of the file are overwritten
+func Save(fileName string, doc *Document) {
+	os.WriteFile(fileName, []byte(Content(*doc)), fs.FileMode(os.O_RDWR))
 }
 
 //////////////////////

--- a/crdt/woot.go
+++ b/crdt/woot.go
@@ -57,11 +57,17 @@ func Load(fileName string) (Document, error) {
 	pos := 1
 	for i := 0; i < len(lines); i++ {
 		for j := 0; j < len(lines[i]); j++ {
-			doc.Insert(pos, string(lines[i][j]))
+			_, err := doc.Insert(pos, string(lines[i][j]))
+			if err != nil {
+				return doc, err
+			}
 			pos++
 		}
 		if i < len(lines)-1 {
-			doc.Insert(pos, "\n")
+			_, err := doc.Insert(pos, "\n")
+			if err != nil {
+				return doc, err
+			}
 			pos++
 		}
 	}
@@ -69,8 +75,8 @@ func Load(fileName string) (Document, error) {
 }
 
 // Save writes data to the named file, creating it if necessary. The contents of the file are overwritten
-func Save(fileName string, doc *Document) {
-	os.WriteFile(fileName, []byte(Content(*doc)), fs.FileMode(os.O_RDWR))
+func Save(fileName string, doc *Document) error {
+	return os.WriteFile(fileName, []byte(Content(*doc)), fs.FileMode(os.O_RDWR))
 }
 
 //////////////////////

--- a/crdt/woot.go
+++ b/crdt/woot.go
@@ -49,11 +49,11 @@ func New() Document {
 // Load reads a text file from disk and converts it into a CRDT document.
 func Load(fileName string) (Document, error) {
 	doc := New()
-	b, err := os.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
 		return doc, err
 	}
-	lines := strings.Split(string(b), "\n")
+	lines := strings.Split(string(content), "\n")
 	pos := 1
 	for i := 0; i < len(lines); i++ {
 		for j := 0; j < len(lines[i]); j++ {
@@ -63,7 +63,7 @@ func Load(fileName string) (Document, error) {
 			}
 			pos++
 		}
-		if i < len(lines)-1 {
+		if i < len(lines)-1 { // avoids insertion of '\n' on last line
 			_, err := doc.Insert(pos, "\n")
 			if err != nil {
 				return doc, err

--- a/crdt/woot.go
+++ b/crdt/woot.go
@@ -41,7 +41,7 @@ var (
 	ErrBoundsNotPresent    = errors.New("subsequence bound(s) not present")
 )
 
-// New returns a initialized document.
+// New returns an initialized document.
 func New() Document {
 	return Document{Characters: []Character{CharacterStart, CharacterEnd}}
 }

--- a/crdt/woot.go
+++ b/crdt/woot.go
@@ -3,7 +3,6 @@ package crdt
 import (
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"strings"
 )
@@ -74,9 +73,9 @@ func Load(fileName string) (Document, error) {
 	return doc, err
 }
 
-// Save writes data to the named file, creating it if necessary. The contents of the file are overwritten
+// Save writes data to the named file, creating it if necessary. The contents of the file are overwritten.
 func Save(fileName string, doc *Document) error {
-	return os.WriteFile(fileName, []byte(Content(*doc)), fs.FileMode(os.O_RDWR))
+	return os.WriteFile(fileName, []byte(Content(*doc)), 0644)
 }
 
 //////////////////////


### PR DESCRIPTION
Added the ability to save and load files. If the client is run with the '-file' flag, the user will be prompted to enter the name of a file to save to and load from. Pressing Ctrl-s in the editor will overwrite the contents of the file with the contents of the CRDT document. Pressing Ctrl-l will update the editor with the contents of the file, and sync every other client's editor as well.

Some possible improvements for this feature:

- A better way to select files
- The ability to change what file you're saving to or loading from
- A warning, message, or prompt that a sync is about to overwrite the contents of the editor